### PR TITLE
Fixing up ConversationListScreen and ChatScreen and refactoring model and db classes based on Firebase Schema

### DIFF
--- a/common/data/src/main/java/com/packt/data/database/AppUser.kt
+++ b/common/data/src/main/java/com/packt/data/database/AppUser.kt
@@ -1,0 +1,15 @@
+package com.packt.data.database
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "users")
+data class AppUser(
+    @PrimaryKey val userId: String, // Firestore document ID
+    val avatarUrl: String = "",
+    val displayName: String = "",
+    val lastActive: Long = 0L, // Store as epoch millis
+    val phone: String = "",
+    val status: String = "",
+    val username: String = ""
+)

--- a/common/data/src/main/java/com/packt/data/database/AppUserDao.kt
+++ b/common/data/src/main/java/com/packt/data/database/AppUserDao.kt
@@ -1,0 +1,16 @@
+package com.packt.data.database
+
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface AppUserDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertUser(user: AppUser)
+
+    @Query("SELECT * FROM users WHERE userId = :userId")
+    suspend fun getUserById(userId: String): AppUser?
+}

--- a/common/data/src/main/java/com/packt/data/database/ChatAppDatabase.kt
+++ b/common/data/src/main/java/com/packt/data/database/ChatAppDatabase.kt
@@ -1,36 +1,42 @@
 package com.packt.data.database
 
+import com.packt.data.database.AppUser
+import com.packt.data.database.AppUserDao
 import android.content.Context
-import android.util.Log
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
 
+@Database(
+    entities = [
+        Conversation::class,
+        Message::class,
+        AppUser::class
+    ],
+    version = 1,
+    exportSchema = false
+)
+abstract class ChatAppDatabase : RoomDatabase() {
 
-@Database(entities = [Message::class, Conversation::class], version = 1)
-abstract class ChatAppDatabase(): RoomDatabase() {
+    abstract fun chatDao(): ConversationDao
     abstract fun messageDao(): MessageDao
-    abstract fun conversationDao(): ConversationDao
-
+    abstract fun appUserDao(): AppUserDao
 
     companion object {
         @Volatile
         private var INSTANCE: ChatAppDatabase? = null
 
-        fun getDatabase(context: Context): ChatAppDatabase{
-            return INSTANCE ?: synchronized(this){
+        fun getDatabase(context: Context): ChatAppDatabase {
+            return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     ChatAppDatabase::class.java,
-                    "chat_database"
-                ).build()
+                    "chat_app_database"
+                ).fallbackToDestructiveMigration(dropAllTables = true) // 👈 THIS DROPS AND REBUILDS THE DB
+                    .build()
                 INSTANCE = instance
                 instance
             }
-
         }
     }
-
 }

--- a/common/data/src/main/java/com/packt/data/database/Conversation.kt
+++ b/common/data/src/main/java/com/packt/data/database/Conversation.kt
@@ -8,8 +8,14 @@ import androidx.room.PrimaryKey
 
 data class Conversation(
     @PrimaryKey
-    val conversationId: String,
-    @ColumnInfo(name = "last_message_time")
-    val lastMessageTime: Long
+    val chatId: String, // Firestore Document ID of the chat
 
+    val chatType: String?,
+    val createdAt: Long?, // Store Timestamp as epoch millis
+    val lastMessage: String?,
+    val lastMessageTimestamp: Long?,
+    val profileImageUrl: String?,
+    val title: String?,
+    val unreadAccount: String?,
+    val unreadCount: Int?
 )

--- a/common/data/src/main/java/com/packt/data/database/ConversationDao.kt
+++ b/common/data/src/main/java/com/packt/data/database/ConversationDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ConversationDao {
 
-    @Query("SELECT * FROM conversations ORDER BY last_message_time DESC")
+    @Query("SELECT * FROM conversations ORDER BY lastMessageTimestamp DESC")
     fun getAllConversations(): Flow<List<Conversation>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/common/data/src/main/java/com/packt/data/database/Message.kt
+++ b/common/data/src/main/java/com/packt/data/database/Message.kt
@@ -9,44 +9,33 @@ import java.time.Instant
 
 @Entity(
     tableName = "messages",
-    foreignKeys = [
-        ForeignKey(
-            entity = Conversation::class,
-            parentColumns = arrayOf("conversationId"),
-            childColumns = arrayOf("conversation_id"),
-            onDelete = ForeignKey.CASCADE
-        )
-    ],
-    indices = [
-        Index(value = ["conversation_id"])
-    ]
+    foreignKeys = [ForeignKey(
+        entity = Conversation::class,
+        parentColumns = ["chatId"],
+        childColumns = ["chatId"],
+        onDelete = ForeignKey.CASCADE
+    )],
+    indices = [Index("chatId")]
 )
-
 data class Message(
     @PrimaryKey(autoGenerate = true)
-    val id: Int,
-    @ColumnInfo(name = "conversation_id")
-    val conversationId: String,
-    @ColumnInfo(name = "sender")
-    val sender: String,
-    @ColumnInfo(name = "content")
-    val content: String,
+    val localId: Int = 0,
+
+    @ColumnInfo(name = "chatId")
+    val chatId: String, // This is NOT in Firestore message doc, but from path /chats/{chatId}/messages
+
+    @ColumnInfo(name = "id")
+    val id: String? = null,
+
     @ColumnInfo(name = "timestamp")
-    val timestamp: String
-) {
+    val timestamp: String? = null,
 
-    companion object {
+    @ColumnInfo(name = "content_type")
+    val contentType: String = "TEXT",
 
-        fun fromDomain(id: String?,
-                       senderName: String,
-                       content: String,
-                       timestamp: String): Message{
-         return Message(   id = 0,
-             conversationId = id!!,
-             sender = senderName,
-             content = content,
-             timestamp = timestamp)
-        }
-    }
-}
+    @ColumnInfo(name = "content")
+    val content: String = "",
 
+    @ColumnInfo(name = "content_description")
+    val contentDescription: String = ""
+)

--- a/common/data/src/main/java/com/packt/data/database/MessageDao.kt
+++ b/common/data/src/main/java/com/packt/data/database/MessageDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface MessageDao {
 
-    @Query("SELECT * FROM messages WHERE conversation_id = :conversation_id ORDER BY timestamp ASC")
+    @Query("SELECT * FROM messages WHERE id = :conversation_id ORDER BY timestamp ASC")
     fun getMessagesInConversation(conversation_id: Int): Flow<List<Message>>
 
     @Insert

--- a/common/data/src/main/java/com/packt/data/di/DatabaseModule.kt
+++ b/common/data/src/main/java/com/packt/data/di/DatabaseModule.kt
@@ -29,6 +29,6 @@ object DatabaseModule {
 
     @Provides
     fun providesConversationsDao(database: ChatAppDatabase): ConversationDao {
-        return database.conversationDao()
+        return database.chatDao()
     }
 }

--- a/feature/chat/src/main/java/com/packt/chat/data/network/datasource/MessagesSocketDataSource.kt
+++ b/feature/chat/src/main/java/com/packt/chat/data/network/datasource/MessagesSocketDataSource.kt
@@ -1,116 +1,116 @@
-package com.packt.chat.data.network.datasource
-
-import android.util.Log
-import androidx.compose.runtime.LaunchedEffect
-import com.packt.chat.data.model.WebsocketMessageModel
-import com.packt.chat.di.ChatModule.Companion.WEBSOCKET_CLIENT
-import com.packt.chat.di.ChatModule.Companion.WEBSOCKET_URL_NAME
-import com.packt.chat.domain.models.Message
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
-import io.ktor.client.plugins.websocket.converter
-import io.ktor.client.plugins.websocket.webSocketSession
-import io.ktor.client.request.url
-import io.ktor.serialization.deserialize
-import io.ktor.serialization.serialize
-import io.ktor.websocket.CloseReason
-import io.ktor.websocket.Frame
-import io.ktor.websocket.close
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.coroutines.flow.retryWhen
-import kotlinx.io.IOException
-import javax.inject.Inject
-import javax.inject.Named
-
-/**
- * What are the steps that are needed for us to create a WebSocket component in Android.
- *
- * 1) We need to create a HTTPClient component for us to manage the facilitation of the
- *    the socket
- *
- *
- * ***/
-
-class MessagesSocketDataSource @Inject constructor(
-    @Named(WEBSOCKET_CLIENT) private val httpClient: HttpClient,
-    @Named(WEBSOCKET_URL_NAME) private val webSocketUrl: String
-) {
-
-    private lateinit var webSocketSession: DefaultClientWebSocketSession
-
-    companion object {
-        val TAG = "MessagesSocketDataSource"
-        val MAX_TRIES = 5
-        val RETRY_DELAY = 1000L
-    }
-
-
-    suspend fun connect(): Flow<Message> {
-
-        return flow {
-
-            try {
-                httpClient.webSocketSession { url(webSocketUrl) } // This line will return a DefaultClientWebSocketSession
-                    .apply { webSocketSession = this } // We use the scope function 'apply' to assign to our webSocketSession: DefaultClientWebSocketSession
-                    .incoming // The incoming property of DefaultClientWebSocketSession, a channel that receives Frame objects
-                    .receiveAsFlow() // Receive the incoming messages as a Flow object
-                    .collect { frame ->
-                        try {
-                            // Handle errors while processing the message
-                            val message = webSocketSession.handleMessage(frame)?.toDomain()
-                            if (message != null) {
-                                emit(message)
-                            }
-                        } catch (e: Exception) {
-                            Log.e(TAG, "Error handling WebSocket frame", e)
-                        }
-                    }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error connecting to WebSocket", e)
-            }
-        }.retryWhen { cause, attempt ->
-            if (cause is IOException && attempt < MAX_TRIES) {
-                delay(RETRY_DELAY)
-                true
-            } else {
-                false
-            }
-        }.catch { e ->
-            Log.e(TAG, "Error in Websocket Flow", e)
-        }
-    }
-
-    suspend fun sendMessage(message: Message) {
-
-        val webSocketMessage = WebsocketMessageModel.fromDomain(message)
-
-        webSocketSession.converter?.serialize(webSocketMessage)?.let {
-            webSocketSession.send(it)
-        }
-    }
-
-    suspend fun disconnect() {
-        webSocketSession.close(CloseReason(CloseReason.Codes.NORMAL, "Disconnect"))
-    }
-
-    /**
-     * Responsible for handling and processing the messages
-     * Takes the incoming Frame object that is coming through the socket and deserializes it into a WebSocketMessageModel object
-     **/
-    private suspend fun DefaultClientWebSocketSession.handleMessage(frame: Frame): WebsocketMessageModel? {
-        return when (frame) {
-            is Frame.Text -> converter?.deserialize(frame)
-            is Frame.Close -> {
-                disconnect()
-                null
-            }
-
-            else -> null
-        }
-    }
-}
+//package com.packt.chat.data.network.datasource
+//
+//import android.util.Log
+//import androidx.compose.runtime.LaunchedEffect
+//import com.packt.chat.data.model.WebsocketMessageModel
+//import com.packt.chat.di.ChatModule.Companion.WEBSOCKET_CLIENT
+//import com.packt.chat.di.ChatModule.Companion.WEBSOCKET_URL_NAME
+//import com.packt.chat.domain.models.Message
+//import io.ktor.client.HttpClient
+//import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+//import io.ktor.client.plugins.websocket.converter
+//import io.ktor.client.plugins.websocket.webSocketSession
+//import io.ktor.client.request.url
+//import io.ktor.serialization.deserialize
+//import io.ktor.serialization.serialize
+//import io.ktor.websocket.CloseReason
+//import io.ktor.websocket.Frame
+//import io.ktor.websocket.close
+//import kotlinx.coroutines.coroutineScope
+//import kotlinx.coroutines.delay
+//import kotlinx.coroutines.flow.Flow
+//import kotlinx.coroutines.flow.catch
+//import kotlinx.coroutines.flow.flow
+//import kotlinx.coroutines.flow.receiveAsFlow
+//import kotlinx.coroutines.flow.retryWhen
+//import kotlinx.io.IOException
+//import javax.inject.Inject
+//import javax.inject.Named
+//
+///**
+// * What are the steps that are needed for us to create a WebSocket component in Android.
+// *
+// * 1) We need to create a HTTPClient component for us to manage the facilitation of the
+// *    the socket
+// *
+// *
+// * ***/
+//
+//class MessagesSocketDataSource @Inject constructor(
+//    @Named(WEBSOCKET_CLIENT) private val httpClient: HttpClient,
+//    @Named(WEBSOCKET_URL_NAME) private val webSocketUrl: String
+//) {
+//
+//    private lateinit var webSocketSession: DefaultClientWebSocketSession
+//
+//    companion object {
+//        val TAG = "MessagesSocketDataSource"
+//        val MAX_TRIES = 5
+//        val RETRY_DELAY = 1000L
+//    }
+//
+//
+//    suspend fun connect(): Flow<Message> {
+//
+//        return flow {
+//
+//            try {
+//                httpClient.webSocketSession { url(webSocketUrl) } // This line will return a DefaultClientWebSocketSession
+//                    .apply { webSocketSession = this } // We use the scope function 'apply' to assign to our webSocketSession: DefaultClientWebSocketSession
+//                    .incoming // The incoming property of DefaultClientWebSocketSession, a channel that receives Frame objects
+//                    .receiveAsFlow() // Receive the incoming messages as a Flow object
+//                    .collect { frame ->
+//                        try {
+//                            // Handle errors while processing the message
+//                            //val message = webSocketSession.handleMessage(frame)?.toDomain()
+//                            if (message != null) {
+//                                emit(message)
+//                            }
+//                        } catch (e: Exception) {
+//                            Log.e(TAG, "Error handling WebSocket frame", e)
+//                        }
+//                    }
+//            } catch (e: Exception) {
+//                Log.e(TAG, "Error connecting to WebSocket", e)
+//            }
+//        }.retryWhen { cause, attempt ->
+//            if (cause is IOException && attempt < MAX_TRIES) {
+//                delay(RETRY_DELAY)
+//                true
+//            } else {
+//                false
+//            }
+//        }.catch { e ->
+//            Log.e(TAG, "Error in Websocket Flow", e)
+//        }
+//    }
+//
+//    suspend fun sendMessage(message: Message) {
+//
+//        val webSocketMessage = WebsocketMessageModel.fromDomain(message)
+//
+//        webSocketSession.converter?.serialize(webSocketMessage)?.let {
+//            webSocketSession.send(it)
+//        }
+//    }
+//
+//    suspend fun disconnect() {
+//        webSocketSession.close(CloseReason(CloseReason.Codes.NORMAL, "Disconnect"))
+//    }
+//
+//    /**
+//     * Responsible for handling and processing the messages
+//     * Takes the incoming Frame object that is coming through the socket and deserializes it into a WebSocketMessageModel object
+//     **/
+//    private suspend fun DefaultClientWebSocketSession.handleMessage(frame: Frame): WebsocketMessageModel? {
+//        return when (frame) {
+//            is Frame.Text -> converter?.deserialize(frame)
+//            is Frame.Close -> {
+//                disconnect()
+//                null
+//            }
+//
+//            else -> null
+//        }
+//    }
+//}

--- a/feature/chat/src/main/java/com/packt/chat/data/network/model/ChatRoomModel.kt
+++ b/feature/chat/src/main/java/com/packt/chat/data/network/model/ChatRoomModel.kt
@@ -17,7 +17,7 @@ data class ChatRoomModel(
             id = id,
             senderName = senderName,
             senderAvatar = senderAvatar,
-            lastMessages = lastMessages.map { it.toDomain() }
+            lastMessages = lastMessages.map { it.toDomain() } // 👈 map each WebsocketMessageModel to domain.Message
         )
     }
 }

--- a/feature/chat/src/main/java/com/packt/chat/data/network/model/WebsocketMessageModel.kt
+++ b/feature/chat/src/main/java/com/packt/chat/data/network/model/WebsocketMessageModel.kt
@@ -18,12 +18,19 @@ class WebsocketMessageModel(
         const val TYPE_TEXT = "TEXT"
         const val TYPE_IMAGE = "IMAGE"
 
-        // Takes the current Message from the Domain layer anc converts it into a WebsocketMessageModel
-        fun fromDomain(message: Message): WebsocketMessageModel {
+        /**
+         * Converts a domain [Message] into a [WebsocketMessageModel].
+         * Since domain.Message doesn't contain senderName/senderAvatar, they must be passed separately.
+         */
+        fun fromDomain(
+            message: Message,
+            senderName: String,
+            senderAvatar: String
+        ): WebsocketMessageModel {
             return WebsocketMessageModel(
                 id = message.id,
-                senderName = message.senderName,
-                senderAvatar = message.senderAvatar,
+                senderName = senderName,
+                senderAvatar = senderAvatar,
                 timestamp = message.timestamp,
                 isMine = message.isMine,
                 messageType = message.fromContentType(),
@@ -33,12 +40,13 @@ class WebsocketMessageModel(
         }
     }
 
-    // Converts the WebSocketMessage Model into a Message object within the domain layer
+    /**
+     * Converts this WebSocket model into a domain-layer [Message].
+     * senderName and senderAvatar are intentionally not passed into the domain model.
+     */
     fun toDomain(): Message {
         return Message(
             id = id,
-            senderName = senderName,
-            senderAvatar = senderAvatar,
             timestamp = timestamp,
             isMine = isMine,
             contentType = toContentType(),
@@ -47,17 +55,18 @@ class WebsocketMessageModel(
         )
     }
 
-    fun toContentType(): Message.ContentType {
-        return when (messageType) {
+    private fun toContentType(): Message.ContentType {
+        return when (messageType.uppercase()) {
             TYPE_IMAGE -> Message.ContentType.IMAGE
             else -> Message.ContentType.TEXT
         }
     }
 }
 
+// Extension function to convert contentType enum into string
 fun Message.fromContentType(): String {
     return when (contentType) {
-      Message.ContentType.IMAGE -> WebsocketMessageModel.TYPE_IMAGE
+        Message.ContentType.IMAGE -> WebsocketMessageModel.TYPE_IMAGE
         else -> WebsocketMessageModel.TYPE_TEXT
     }
 }

--- a/feature/chat/src/main/java/com/packt/chat/data/network/repository/BackupRepository.kt
+++ b/feature/chat/src/main/java/com/packt/chat/data/network/repository/BackupRepository.kt
@@ -26,7 +26,7 @@ class BackupRepository @Inject constructor(
             for (conversation in it) {
 
                 val messages =
-                    messageDao.getMessagesInConversation(conversation_id = conversation.conversationId.toInt())
+                    messageDao.getMessagesInConversation(conversation_id = conversation.chatId.toInt())
 
                 // Create a JSON representation of the messages
                 val messagesJson = gson.toJson(messages)
@@ -37,7 +37,7 @@ class BackupRepository @Inject constructor(
                 tempFile.writeText(messagesJson)
 
                 // Upload the file to Firebase Storage
-                val remotePath = "conversations/{${conversation.conversationId}/messages}"
+                val remotePath = "conversations/{${conversation.chatId}/messages}"
                 storageDataSource.uploadFile(tempFile, remotePath)
 
                 // Delete the local file

--- a/feature/chat/src/main/java/com/packt/chat/data/network/repository/ChatRoomRepository.kt
+++ b/feature/chat/src/main/java/com/packt/chat/data/network/repository/ChatRoomRepository.kt
@@ -3,6 +3,7 @@ package com.packt.chat.data.network.repository
 import com.packt.chat.data.network.datasource.ChatRoomDataSource
 import com.packt.chat.domain.IChatRoomRepository
 import com.packt.chat.domain.models.ChatRoom
+import com.packt.chat.ui.model.Chat
 import javax.inject.Inject
 
 class ChatRoomRepository @Inject constructor(

--- a/feature/chat/src/main/java/com/packt/chat/domain/models/Message.kt
+++ b/feature/chat/src/main/java/com/packt/chat/domain/models/Message.kt
@@ -4,9 +4,7 @@ import com.google.firebase.Timestamp
 import com.packt.chat.data.network.model.FireStoreMessageModel
 
 data class Message(
-    val id: String? = null,
-    val senderName: String = "",
-    val senderAvatar: String = "",
+    val id: String? = null, // This maps to senderId
     val timestamp: String? = null,
     val isMine: Boolean = false,
     val contentType: ContentType = ContentType.TEXT,
@@ -15,14 +13,15 @@ data class Message(
 ) {
 
     enum class ContentType {
-        TEXT, IMAGE
+        TEXT, IMAGE, VIDEO
     }
 
     fun toFireStoreMessageModel(): FireStoreMessageModel {
         return FireStoreMessageModel(
-            id = id ?: "",
-            senderName = senderName,
-            senderAvatar = senderAvatar
+            senderId = id ?: "",
+            content = content,
+            messageType = contentType.name.lowercase(),
+            timestamp = Timestamp.now()
         )
     }
 }

--- a/feature/chat/src/main/java/com/packt/chat/ui/ChatScreen.kt
+++ b/feature/chat/src/main/java/com/packt/chat/ui/ChatScreen.kt
@@ -53,8 +53,7 @@ fun ChatScreen(
     val uiState by viewModel.uiState.collectAsState()
 
     LaunchedEffect(messages.size) {
-        viewModel.loadInitialChatInformation(chatId.orEmpty())
-        viewModel.observeMessages(chatId.orEmpty())
+        viewModel.loadAndObserveChat(chatId.orEmpty())
     }
 
     Scaffold(topBar = {

--- a/feature/chat/src/main/java/com/packt/chat/ui/MessageItem.kt
+++ b/feature/chat/src/main/java/com/packt/chat/ui/MessageItem.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -29,37 +28,33 @@ import com.packt.framework.ui.Avatar
 
 @Composable
 fun MessageItem(message: Message) {
-
     Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = if (message.isMine) {
-            Arrangement.End
-        } else {
-            Arrangement.Start
-        }
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = if (message.isMine) Arrangement.End else Arrangement.Start
     ) {
+        // Show avatar if not from the current user
         if (!message.isMine) {
             Avatar(
                 imageUrl = message.senderAvatar,
                 size = 40.dp,
                 contentDescription = "${message.senderName}'s avatar"
             )
+            Spacer(modifier = Modifier.width(8.dp))
         }
 
-        Spacer(modifier = Modifier.width(8.dp))
-
         Column {
-            if (message.isMine) {
-                Spacer(modifier = Modifier.height(8.dp))
-            } else {
+            if (!message.isMine) {
                 Text(
                     text = message.senderName,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.sp
                 )
+                Spacer(modifier = Modifier.height(4.dp))
             }
 
             when (val content = message.messageContent) {
-
                 is MessageContent.TextMessage -> {
                     Surface(
                         shape = RoundedCornerShape(8.dp),
@@ -75,7 +70,7 @@ fun MessageItem(message: Message) {
                             color = if (message.isMine) {
                                 MaterialTheme.colorScheme.onPrimary
                             } else {
-                                Color.White
+                                MaterialTheme.colorScheme.onSecondary
                             }
                         )
                     }
@@ -86,20 +81,23 @@ fun MessageItem(message: Message) {
                         model = content.imageUrl,
                         contentDescription = content.contentDescription,
                         modifier = Modifier
-                            .size(40.dp)
-                            .clip(CircleShape),
+                            .size(150.dp)
+                            .clip(RoundedCornerShape(8.dp)),
                         contentScale = ContentScale.Crop
                     )
                 }
 
+                is MessageContent.VideoMessage -> {
+                    // TODO: Handle video rendering
+                }
             }
 
+            Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = message.timestamp,
-                fontSize = 12.sp
+                fontSize = 12.sp,
+                color = Color.Gray
             )
         }
-
     }
-
 }

--- a/feature/chat/src/main/java/com/packt/chat/ui/model/Message.kt
+++ b/feature/chat/src/main/java/com/packt/chat/ui/model/Message.kt
@@ -16,4 +16,9 @@ sealed class MessageContent {
         val imageUrl: String,
         val contentDescription: String
     ) : MessageContent()
+
+    data class VideoMessage(
+        val imageUrl: String,
+        val contentDescription: String
+    ) : MessageContent()
 }


### PR DESCRIPTION
ChatScreen can display the non-app users' display name on the top of the scaffold's top app bar, and it can also display the non-app user's avatar next to their message.

ConversationListScreen can pull the latest data from the back end.

I also did a lot of refactoring of the model classes in the domain layer to the chat feature, as well as the common data database model classes, to match what I have defined in the Firebase schema

Refactored Room and the Dao Classes. 

Added AppUser which will be responsible for storing new users into the database


 

